### PR TITLE
Fix typo error: 'geneate' -> 'generate'

### DIFF
--- a/pages/add-personal-access-token.tsx
+++ b/pages/add-personal-access-token.tsx
@@ -171,7 +171,7 @@ export default function AddPersonalAccessToken() {
               4- Scroll down and select the{" "}
               <span className="font-medium">« gist »</span> box, then scroll
               down again and click on{" "}
-              <span className="font-medium">« Geneate token »</span>.
+              <span className="font-medium">« Generate token »</span>.
             </p>
             <Image
               src="/guides/add-personal-access-token-2.png"


### PR DESCRIPTION
This pull request fixes a typo in the code where the word "geneate" was incorrectly spelled instead of "generate". The typo has been corrected in the relevant file(s) and the code has been tested to ensure that it works as intended. This change will improve the readability and clarity of the code for future contributors.